### PR TITLE
Docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,21 @@ or
 sudo dpkg -i ../porto_*.deb
 ```
 
+## Build in Docker
+
+To build in docker's container docker and docker-buildx should be installed
+
+```bash
+sudo apt install -y \
+    docker.io \
+    docker-buildx 
+```
+Command as follows creates necessary binaries in build directory of porto source tree
+```bash
+docker build -t env_ubuntu22.04 -f scripts/Dockerfile .
+docker run -v $(pwd):/porto docker.io/library/env_ubuntu22.04 bash -c "mkdir /porto/build; cd /porto/build; cmake ..; make -j4"
+```
+
 ## Run
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ sudo apt install -y \
     zlib1g-dev \
     pandoc \
     libseccomp-dev \
+    libtool-bin \
     libbpf-dev # for focal or newer
 
 # dependencies for deb package building

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+FROM ubuntu:22.04
+
+RUN apt update
+
+RUN apt install -y \
+    g++ \
+    cmake \
+    protobuf-compiler \
+    libprotobuf-dev \
+    libgoogle-perftools-dev \
+    libnl-3-dev \
+    libnl-genl-3-dev \
+    libnl-route-3-dev \
+    libnl-idiag-3-dev \
+    libncurses5-dev \
+    libelf-dev \
+    zlib1g-dev \
+    pandoc \
+    libseccomp-dev \
+    libtool-bin \
+    libbpf-dev
+
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at:  https://yandex.ru/legal/cla/?lang=en.


Now it's not possible to build porto on Ubuntu 24.04 without any source code or/and CMakeFiles modification. The problems now as follows:
1. forward declaration of enum bpf_link_type {}, hope it will be solved in https://github.com/ten-nancy/porto/pull/4
2. incompatibility of libelf and zlib raises:
```
    /usr/bin/ld: /usr/lib/gcc/aarch64-linux-gnu/13/../../../aarch64-linux-gnu/libelf.a(elf_compress.o): in function __libelf_compress':

(.text+0xdc): undefined reference to `ZSTD_createCCtx'

/usr/bin/ld: (.text+0x1b4): undefined reference to `ZSTD_compressStream2'

/usr/bin/ld: (.text+0x1bc): undefined reference to `ZSTD_isError'

```

3. assignment in parentheses in cpp code, in none clang build (gcc (Ubuntu 13.2.0-23ubuntu4) 13.2.0) raises:

```
/home/aperevalov/src/github.com/ten-nancy/porto/src/nbd.cpp:261:19: warning: suggest parentheses around 
assignment used as truth value [-Wparentheses]

  261 |         if (error = sock.Read(buf, 124)) {


```
Reasonable to compile it in env where it could be compiled, and then make CMakeFiles and source more robust to different environments.